### PR TITLE
Make passport fields readonly on the registration screen

### DIFF
--- a/ui/app/common/attributeTypes/directives/attributeTypes.js
+++ b/ui/app/common/attributeTypes/directives/attributeTypes.js
@@ -16,11 +16,18 @@ angular.module('bahmni.common.attributeTypes', []).directive('attributeTypes', [
         templateUrl: '../common/attributeTypes/views/attributeInformation.html',
         restrict: 'E',
         controller: function ($scope) {
+            const readonlyFields = [
+                "Passport Country Code",
+                "Passport Country Name",
+                "Passport Number"
+            ];
             $scope.getAutoCompleteList = $scope.getAutoCompleteList();
             $scope.getDataResults = $scope.getDataResults();
             // to avoid watchers in one way binding
             $scope.isAutoComplete = $scope.isAutoComplete() || function () { return false; };
-            $scope.isReadOnly = $scope.isReadOnly() || function () { return false; };
+            $scope.isReadOnly = $scope.isReadOnly() || function (field) {
+                return readonlyFields.indexOf(field) !== -1;
+            };
             $scope.handleUpdate = $scope.handleUpdate() || function () { return false; };
 
             $scope.appendConceptNameToModel = function (attribute) {

--- a/ui/app/common/attributeTypes/directives/attributeTypes.js
+++ b/ui/app/common/attributeTypes/directives/attributeTypes.js
@@ -19,7 +19,8 @@ angular.module('bahmni.common.attributeTypes', []).directive('attributeTypes', [
             const readonlyFields = [
                 "Passport Country Code",
                 "Passport Country Name",
-                "Passport Number"
+                "Passport Number",
+                "Beneficiary Group Name"
             ];
             $scope.getAutoCompleteList = $scope.getAutoCompleteList();
             $scope.getDataResults = $scope.getDataResults();


### PR DESCRIPTION
TCW set readonly property to true on passport fields that are synced from subscriber Admin